### PR TITLE
Fixes for gamecore.Device

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -35,9 +35,11 @@ gamecore.Device = gamecore.Base.extend('gamecore.Device',
             this.isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') != -1;
             this.isChrome = navigator.userAgent.toLowerCase().indexOf('chrome') != -1;
             this.isOpera = navigator.userAgent.toLowerCase().indexOf('opera') != -1;
-            this.isTouch = "ontouchstart" in window;
+            this.isTouch = window.ontouchstart !== 'undefined';
 
-            this.hasMemoryProfiling = (window.performance.memory);
+            this.hasMemoryProfiling =
+                window.performance !== 'undefined' &&
+                    window.performance.memory !== 'undefined';
 
             if (/MSIE (\d+\.\d+);/.test(navigator.userAgent))
             {
@@ -55,7 +57,7 @@ gamecore.Device = gamecore.Base.extend('gamecore.Device',
                         window.msRequestAnimationFrame ||
                         function (callback, element)
                         {
-                            window.setTimeout(callback, 1000 / this.fps);
+                            window.setTimeout(callback, 16, Date.now());
                         };
 
                 // apply to our window global to avoid illegal invocations (it's a native)


### PR DESCRIPTION
Define default FPS for requestAnimationFrame fallback (16ms frames)
Pass timestamp to RAF callback to fit spec **
Fix profiling check where window.performance may not exist
Use consistent and faster undefined check (http://jsperf.com/hasownproperty-vs-in-vs-undefined/12)

*\* NOTE: Date.now() is not supported in IE8. +new Date can be used instead, but it isn't as fast. IE8 doesn't natively support canvas anyway, so this may not be an issue. (http://jsperf.com/new-date-value/9). I've opted for the faster version because it will have to be called on every frame.
